### PR TITLE
Updated codemirror.js location (from src to lib) to fix code highlights

### DIFF
--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte'
-  import CodeMirror from 'codemirror/src/codemirror.js'
+  import CodeMirror from 'codemirror/lib/codemirror.js'
 
   let classes = ''
 


### PR DESCRIPTION
import CodeMirror from 'codemirror/lib/codemirror.js'

seems the right location for codemirror.js

Check this out:
<img width="250" alt="image" src="https://user-images.githubusercontent.com/901975/175406610-151da99b-1fb3-4e96-9a39-0400f0d7d1fd.png">
